### PR TITLE
A couple of ideas

### DIFF
--- a/mutt-notmuch-py
+++ b/mutt-notmuch-py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 mutt-notmuch-py
 

--- a/mutt-notmuch-py
+++ b/mutt-notmuch-py
@@ -24,6 +24,7 @@ Licensed under BSD
 
 import os
 import hashlib
+import readline
 
 from commands import getoutput
 from mailbox import Maildir
@@ -105,4 +106,7 @@ if __name__ == '__main__':
         dest = '~/.cache/mutt_results'
 
     # Use expanduser() so that os.symlink() won't get weirded out by tildes.
-    main(os.path.expanduser(dest).rstrip('/'), options.gmail)
+    try:
+        main(os.path.expanduser(dest).rstrip('/'), options.gmail)
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
- specify Python2 executable since it won't work with python3 (i think)
- readline (vi mode for command line)  maybe make this configurable for emacs brethren.
- catch keyboard interrupt - useful if it's taking too long to search