### PR TITLE
Filter on basedir

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 mutt-notmuch-py
 ===============
 
-This is a Gmail-only version of the original mutt-notmuch script.
+This is a python version of the original mutt-notmuch script.
 
 It will interactively ask you for a search query and then symlink the matching
 messages to ``$HOME/.cache/mutt_results``.
@@ -18,7 +18,13 @@ query.
 
 Install this by adding this file somewhere on your PATH.
 
-Only tested on OSX Lion.
+Only tested on OSX Lion, OSX El Capitan.
+
+Options
+-------
+-g        Use gmail specific info (All Mail search)
+-G        Do not use gmail specific info
+-p [path] Limit search results to files with path in the path name
 
 License
 -------

--- a/mutt-notmuch-py
+++ b/mutt-notmuch-py
@@ -51,7 +51,9 @@ def command(cmd):
     return getoutput(cmd)
 
 
-def main(dest_box, is_gmail):
+def main(dest_box, options):
+    is_gmail = options.gmail
+    filter_path = options.base_path
     query = raw_input('Query: ')
 
     command('mkdir -p %s/cur' % dest_box)
@@ -66,6 +68,9 @@ def main(dest_box, is_gmail):
 
     for f in files:
         if not f:
+            continue
+
+        if filter_path is not None and filter_path not in f:
             continue
 
         try:
@@ -97,6 +102,8 @@ if __name__ == '__main__':
     p.add_option('-G', '--not-gmail', dest='gmail',
                  action='store_false',
                  help='Normal, non-gmail-specific behavior')
+    p.add_option('-p', '--base-path', dest='base_path',
+                 help='Only include messages in given base path')
     (options, args) = p.parse_args()
 
     if args:
@@ -105,4 +112,4 @@ if __name__ == '__main__':
         dest = '~/.cache/mutt_results'
 
     # Use expanduser() so that os.symlink() won't get weirded out by tildes.
-    main(os.path.expanduser(dest).rstrip('/'), options.gmail)
+    main(os.path.expanduser(dest).rstrip('/'), options)

--- a/mutt-notmuch-py
+++ b/mutt-notmuch-py
@@ -16,7 +16,7 @@ This script overrides the $HOME/.cache/mutt_results each time you run a query.
 
 Install this by adding this file somewhere on your PATH.
 
-Tested on OSX Lion and Arch Linux.
+Tested on OSX Lion, OSX El Capitan and Arch Linux.
 
 (c) 2012 - Honza Pokorny
 Licensed under BSD
@@ -96,7 +96,7 @@ if __name__ == '__main__':
                  help='gmail-specific behavior')
     p.add_option('-G', '--not-gmail', dest='gmail',
                  action='store_false',
-                 help='gmail-specific behavior')
+                 help='Normal, non-gmail-specific behavior')
     (options, args) = p.parse_args()
 
     if args:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_desc = open('README.rst').read()
 
 setup(
     name='mutt-notmuch',
-    version='1.0.0',
+    version='1.1.0',
     url='https://github.com/honza/mutt-notmuch-py',
     install_requires=[],
     description=description,


### PR DESCRIPTION
If -p is given the files linked to the output dir are limited to source
files that have the path given with -p in the name.

This is usefull if you have a couple of mail accounts, and want to
search only one account.

Example:

I have three email accounts I sync with offlineimap and index them all
together with one notmuch index.
To search globally, I run:
$ mutt-notmuch -g ~/mail/temp/search
To search only my work email, I run:
$ mutt-notmuch -g -p 'mail/work' ~/mail/temp/search

I know I could have done this with multiple notmuch databases but that
was too much hassle with environment variables, especially with the
combination of offlineimap, mutt, notmuch etc