### PR TITLE
mutt-notmuch-py crashes

### DIFF
--- a/mutt-notmuch-py
+++ b/mutt-notmuch-py
@@ -25,7 +25,7 @@ Licensed under BSD
 import os
 import hashlib
 
-from commands import getoutput
+from commands import getoutput, mkarg
 from mailbox import Maildir
 from optparse import OptionParser
 from collections import defaultdict
@@ -61,7 +61,7 @@ def main(dest_box, options):
 
     empty_dir(dest_box)
 
-    files = command('notmuch search --output=files %s' % query).split('\n')
+    files = command('notmuch search --output=files %s' % mkarg(query)).split('\n')
 
     data = defaultdict(list)
     messages = []


### PR DESCRIPTION
mutt-notmuch-py will crash when given an input with shell special characters, such as:
(testing)

This fix calls the mkarg function from commands module (which is undocumented, but is apparently the only correct function to use in Python 2) on the user input, thus escaping it correctly for use in an command argument:
http://stackoverflow.com/questions/35817/how-to-escape-os-system-calls-in-python