### PR TITLE
Shell-escape searches

### DIFF
--- a/mutt-notmuch-py
+++ b/mutt-notmuch-py
@@ -25,6 +25,12 @@ Licensed under BSD
 from __future__ import print_function
 import os
 import hashlib
+
+try:
+    from shlex import quote
+except:
+    from pipes import quote
+
 import sys
 
 from mailbox import Maildir
@@ -87,7 +93,7 @@ def main(dest_box, options):
 
     empty_dir(dest_box)
 
-    files = command('notmuch search --output=files {}'.format(query)).split('\n')
+    files = command('notmuch search --output=files {}'.format(quote(query))).split('\n')
 
     data = defaultdict(list)
     messages = []

--- a/mutt-notmuch-py
+++ b/mutt-notmuch-py
@@ -28,7 +28,7 @@ import hashlib
 
 try:
     from shlex import quote
-except:
+except ImportError:
     from pipes import quote
 
 import sys


### PR DESCRIPTION
I found that doing a search with parens was falling foul of shell escaping issues:

    Query: from:greg (ruby NEAR version)
    sh: -c: line 0: syntax error near unexpected token `('
    sh: -c: line 0: `{ notmuch search --output=files from:greg (ruby NEAR version); } 2>&1'

The solution is to shell escape, using `shlex.quote` when available (ie. Python 3.3), and `pipes.quote` otherwise:

-  https://docs.python.org/3/library/shlex.html#shlex.quote
-  https://docs.python.org/2/library/pipes.html#pipes.quote

As the `pipes.doc` docs say:

> Deprecated since version 2.7: Prior to Python 2.7, this function was not publicly documented. It is finally exposed publicly in Python 3.3 as the `quote` function in the `shlex` module.

So I am doing a `try`/`except` style of import.